### PR TITLE
Extra Tanks

### DIFF
--- a/src/improved/RBDnew01/rbdnew01.lua
+++ b/src/improved/RBDnew01/rbdnew01.lua
@@ -710,9 +710,6 @@ function Start()
         GetHandle("svfigh4_wingman"),
         GetHandle("svfigh5_wingman")
     };
-    for i,v in pairs(spawnAtPath("bvtank",1,"extra_tanks")) do
-        --Follow(v,GetPlayerHandle(),0);
-    end
 
     local instance = cinematic:start();
     local instance2 = patrolControl:start();


### PR DESCRIPTION
-Player was given extra tanks in both the BZN and the lua. Removed them from the lua because redundancy is redundant.

Fixes #116 